### PR TITLE
Fix  flower mutation activation text in *alien_effect

### DIFF
--- a/2.05-custom-gx/item.hsp
+++ b/2.05-custom-gx/item.hsp
@@ -4578,7 +4578,7 @@
 	if ( tc == CHARA_PLAYER ) {
 		if ( trait(TRAIT_ETHER_BLOOMING_FLOWER) != 0 ) {
 			if ( synccheck(tc, -1) ) {
-				txt lang("しかしすぐに花の養分に変えられた。", "But " + he(tc) + " rapidly breaks it down into nutrients for " + his(tc) + " flowers.")
+				txt lang("しかしすぐに花の養分に変えられた。", "But " + he(tc) + " rapidly break" + _s(tc) + " it down into nutrients for " + his(tc) + " flowers.")
 			}
 			ninsin = 0
 			return


### PR DESCRIPTION
Now it should say "you rapidly break it down" instead of "you rapidly breaks it down".