### PR TITLE
Add plural handling for debris

### DIFF
--- a/2.05-custom-gx/item_func.hsp
+++ b/2.05-custom-gx/item_func.hsp
@@ -1867,6 +1867,7 @@
 						case ITEM_ID_DOWSING_OPATOS
 						case ITEM_ID_SCISSORS
 						case ITEM_ID_CROP_MANAGEMENT_TOOLS
+						case ITEM_ID_MEMORY_FRAGMENT
 							check_string_ending = 0
 							swbreak
 						case ITEM_ID_DISH


### PR DESCRIPTION
This changes, e.g., "5 debrises <Art of Cooking> (Lv. 10)" to "5 debris <Art of Cooking> (Lv. 10)".